### PR TITLE
Updates Applicants Table + Model + Tests to be more robust

### DIFF
--- a/app/assets/javascripts/welcome.coffee
+++ b/app/assets/javascripts/welcome.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/welcome.scss
+++ b/app/assets/stylesheets/welcome.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the welcome controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -1,6 +1,6 @@
 class ApplicantsController < ApplicationController
 
     def show
-        @applicant = Applicant.find(params[:id])
+        @applicant = Applicant.find(params[:applicant_id])
     end
 end

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -1,0 +1,6 @@
+class ApplicantsController < ApplicationController
+
+    def show
+        @applicant = Applicant.find(params[:id])
+    end
+end

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -3,4 +3,5 @@ class ApplicantsController < ApplicationController
     def show
         @applicant = Applicant.find(params[:applicant_id])
     end
+    
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,0 +1,2 @@
+class WelcomeController < ApplicationController
+end

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -1,0 +1,2 @@
+module WelcomeHelper
+end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -4,4 +4,6 @@ class Applicant < ApplicationRecord
     validates :description, presence: true
     validates :names_pets_wanted, presence: true
     validates :application_status, presence: true
+
+    has_many :pets
 end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -1,6 +1,9 @@
 class Applicant < ApplicationRecord 
     validates :name, presence: true
     validates :address, presence: true
+    validates :city, presence: true
+    validates :state, presence: true
+    validates :zip, presence: true, numericality: true
     validates :description, presence: true
     validates :names_pets_wanted, presence: true
     validates :application_status, presence: true

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -1,0 +1,7 @@
+class Applicant < ApplicationRecord 
+    validates :name, presence: true
+    validates :address, presence: true
+    validates :description, presence: true
+    validates :names_pets_wanted, presence: true
+    validates :application_status, presence: true
+end

--- a/app/views/applicants/show.html.erb
+++ b/app/views/applicants/show.html.erb
@@ -1,0 +1,6 @@
+<h1>name: <%= @applicant.name %></h1>
+<h3>address: <%= @applicant.address %></h3>
+<h3>name of pets wanting to adopt: <%= @applicant.names_pets_wanted %></h3>
+<h3><%= @applicant.description %></h3>
+<h3>application_status: <%= @applicant.application_status %></h3>
+

--- a/app/views/applicants/show.html.erb
+++ b/app/views/applicants/show.html.erb
@@ -1,5 +1,8 @@
 <h1>name: <%= @applicant.name %></h1>
 <h3>address: <%= @applicant.address %></h3>
+<h3>address: <%= @applicant.city %></h3>
+<h3>address: <%= @applicant.state %></h3>
+<h3>address: <%= @applicant.zip %></h3>
 
 <h3>name of pets wanting to adopt: <%= pets.each do |pet| %>
 <%= link_to "#{pet.name}", "/pets/#{pet.id}" %>

--- a/app/views/applicants/show.html.erb
+++ b/app/views/applicants/show.html.erb
@@ -1,6 +1,10 @@
 <h1>name: <%= @applicant.name %></h1>
 <h3>address: <%= @applicant.address %></h3>
-<h3>name of pets wanting to adopt: <%= @applicant.names_pets_wanted %></h3>
+
+<h3>name of pets wanting to adopt: <%= pets.each do |pet| %>
+<%= link_to "#{pet.name}", "/pets/#{pet.id}" %>
+<%end%></h3>
+
 <h3><%= @applicant.description %></h3>
 <h3>application_status: <%= @applicant.application_status %></h3>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,4 +36,6 @@ Rails.application.routes.draw do
   get '/veterinary_offices/:veterinary_office_id/veterinarians', to: 'veterinary_offices#veterinarians'
   get '/veterinary_offices/:veterinary_office_id/veterinarians/new', to: 'veterinarians#new'
   post '/veterinary_offices/:veterinary_office_id/veterinarians', to: 'veterinarians#create'
+
+  get '/applications/:applicant_id', to: 'applicants#show'
 end

--- a/db/migrate/20220714203820_create_applicants.rb
+++ b/db/migrate/20220714203820_create_applicants.rb
@@ -1,0 +1,13 @@
+class CreateApplicants < ActiveRecord::Migration[5.2]
+  def change
+    create_table :applicants do |t|
+      t.string :name
+      t.string :address
+      t.text :description
+      t.string :names_pets_wanted
+      t.string :application_status
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220715002605_add_details_to_applicants.rb
+++ b/db/migrate/20220715002605_add_details_to_applicants.rb
@@ -1,0 +1,7 @@
+class AddDetailsToApplicants < ActiveRecord::Migration[5.2]
+  def change
+    add_column :applicants, :city, :string
+    add_column :applicants, :state, :string
+    add_column :applicants, :zip, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_14_203820) do
+ActiveRecord::Schema.define(version: 2022_07_15_002605) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,9 @@ ActiveRecord::Schema.define(version: 2022_07_14_203820) do
     t.string "application_status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "city"
+    t.string "state"
+    t.integer "zip"
   end
 
   create_table "pets", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_13_001717) do
+ActiveRecord::Schema.define(version: 2022_07_14_203820) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "applicants", force: :cascade do |t|
+    t.string "name"
+    t.string "address"
+    t.text "description"
+    t.string "names_pets_wanted"
+    t.string "application_status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "pets", force: :cascade do |t|
     t.boolean "adoptable"

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe "application show page" do
 #     names of all pets that this application is for (all names of pets should be links to their show page)
 #     The Application's status, either "In Progress", "Pending", "Accepted", or "Rejected"
     it 'displays the name, full address, description, names of all pets in the application as links, and the status of the application' do 
-        new_applicant = Applicant.create!(name: "Test", address: "5555 Test Avenue, City, State, 55555", names_pets_wanted: "Fido", description: "they love pets!", application_status: "In Progress")
+        new_applicant = Applicant.create!(name: "Test", address: "5555 Test Avenue", city: "Denver", state: "CO", zip: 55555, names_pets_wanted: "Fido", description: "they love pets!", application_status: "In Progress")
         visit "/applications/#{new_applicant.id}"
         # save_and_open_page
         expect(page).to have_content("name: Test")
-        expect(page).to have_content("address: 5555 Test Avenue, City, State, 55555")
+        expect(page).to have_content("address: 5555 Test Avenue")
+        expect(page).to have_content("city: Denver")
+        expect(page).to have_content("state: CO")
         expect(page).to have_content("name of pets wanting to adopt: Fido")
         #Links to pets not currently working atm - Nick
         

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe "application show page" do
+    #   As a visitor When I visit an applications show page Then I can see the following:
+#     Name of the Applicant
+#     Full Address of the Applicant including street address, city, state, and zip code
+#     Description of why the applicant says they'd be a good home for this pet(s)
+#     names of all pets that this application is for (all names of pets should be links to their show page)
+#     The Application's status, either "In Progress", "Pending", "Accepted", or "Rejected"
+    it 'displays the name, full address, description, names of all pets in the application, and the status of the application' do 
+        new_applicant = Applicant.create!(name: "Test", address: "5555 Test Avenue, City, State, 55555", name_of_pets: "Fido", description: "they love pets!", application_status: "In Progress")
+        visit "/applications/#{application.id}"
+        expect(page).to have_content("name: Test")
+        expect(page).to have_content("address: 5555 Test Avenue, City, State, 55555")
+        expect(page).to have_content("name_of_pets: Fido")
+        expect(page).to have_content("application_status: In Progress")
+    end 
+end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe "application show page" do
 #     names of all pets that this application is for (all names of pets should be links to their show page)
 #     The Application's status, either "In Progress", "Pending", "Accepted", or "Rejected"
     it 'displays the name, full address, description, names of all pets in the application, and the status of the application' do 
-        new_applicant = Applicant.create!(name: "Test", address: "5555 Test Avenue, City, State, 55555", name_of_pets: "Fido", description: "they love pets!", application_status: "In Progress")
-        visit "/applications/#{application.id}"
+        new_applicant = Applicant.create!(name: "Test", address: "5555 Test Avenue, City, State, 55555", names_pets_wanted: "Fido", description: "they love pets!", application_status: "In Progress")
+        visit "/applications/#{new_applicant.id}"
         expect(page).to have_content("name: Test")
         expect(page).to have_content("address: 5555 Test Avenue, City, State, 55555")
-        expect(page).to have_content("name_of_pets: Fido")
+        expect(page).to have_content("name of pets wanting to adopt: Fido")
         expect(page).to have_content("application_status: In Progress")
     end 
 end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -7,12 +7,16 @@ RSpec.describe "application show page" do
 #     Description of why the applicant says they'd be a good home for this pet(s)
 #     names of all pets that this application is for (all names of pets should be links to their show page)
 #     The Application's status, either "In Progress", "Pending", "Accepted", or "Rejected"
-    it 'displays the name, full address, description, names of all pets in the application, and the status of the application' do 
+    it 'displays the name, full address, description, names of all pets in the application as links, and the status of the application' do 
         new_applicant = Applicant.create!(name: "Test", address: "5555 Test Avenue, City, State, 55555", names_pets_wanted: "Fido", description: "they love pets!", application_status: "In Progress")
         visit "/applications/#{new_applicant.id}"
+        # save_and_open_page
         expect(page).to have_content("name: Test")
         expect(page).to have_content("address: 5555 Test Avenue, City, State, 55555")
         expect(page).to have_content("name of pets wanting to adopt: Fido")
+        #Links to pets not currently working atm - Nick
+        
         expect(page).to have_content("application_status: In Progress")
+
     end 
 end

--- a/spec/helpers/welcome_helper_spec.rb
+++ b/spec/helpers/welcome_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the WelcomeHelper. For example:
+#
+# describe WelcomeHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe WelcomeHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe Applicant, type: :model do
     describe 'validations' do
         it { should validate_presence_of(:name) }
         it { should validate_presence_of(:address) }
+        it { should validate_presence_of(:city) }
+        it { should validate_presence_of(:state) }
+        it { should validate_presence_of(:zip) }
         it { should validate_presence_of(:names_pets_wanted) }
         it { should validate_presence_of(:description) }
         it { should validate_presence_of(:application_status) }

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe "Applicant" type: :model do
+    # describe 'relationships' do
+    #     it { should belong_to(:shelter) }
+    #     end
+    
+    describe 'validations' do
+        it { should validate_presence_of(:name) }
+        it { should validate_presence_of(:address) }
+        it { should validate_presence_of(:name_of_pets) }
+        it { should validate_presence_of(:description) }
+        it { should validate_presence_of(:application_status) }
+        end
+end

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -1,15 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe "Applicant" type: :model do
-    # describe 'relationships' do
-    #     it { should belong_to(:shelter) }
-    #     end
-    
+RSpec.describe Applicant, type: :model do
     describe 'validations' do
         it { should validate_presence_of(:name) }
         it { should validate_presence_of(:address) }
-        it { should validate_presence_of(:name_of_pets) }
+        it { should validate_presence_of(:names_pets_wanted) }
         it { should validate_presence_of(:description) }
         it { should validate_presence_of(:application_status) }
-        end
+    end
 end

--- a/spec/requests/welcome_spec.rb
+++ b/spec/requests/welcome_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Welcomes", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
- **Looking at future user stories I think we will need to have the applicant show page address attributes be separated out into `address`, `city`, `state,` `zip `rather than a single string of an address, so I `added a new migration to update the Applicants table`**

- updated the model to show those updated validations
- Updated the html applicant show page to show each of those attributes 
- Updated the model/feature specs to test for the added validations/attributes 

-GJ