### PR TITLE
Fixed typo on line 224 of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ For this story, you should fully leverage ActiveRecord methods in your query.
 
 As a visitor
 When I visit the admin shelter index ('/admin/shelters')
-Then I see a section for "Shelter's with Pending Applications"
+Then I see a section for "Shelters with Pending Applications"
 And in this section I see the name of every shelter that has a pending application
 ```
 


### PR DESCRIPTION
Removed unnecessary apostrophe on line 224 as 'Shelters' should be plural rather than possessive. 